### PR TITLE
Address warnings and notes from devtools::check()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: cssr
 Title: Feature Selection Using Cluster Stability Selection
 Version: 0.0.0.9000
 Authors@R: 
-    c(person("Gregory", "Faletto", , "gregory.faletto@marshall.usc.edu", role = c("aut", 	"cre"), comment = c(ORCID = "0000-0001-8298-1401")),
-	person("Jacob", "Bien", "jbien@usc.edu", role = "aut"))
+    c(person("Gregory", "Faletto", email = "gregory.faletto@marshall.usc.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401")),
+	person("Jacob", "Bien", email = "jbien@usc.edu", role = "aut"))
 Description: Parallelized implementation of cluster stability selection (Faletto
     and Bien 2022). Functions to select clusters and features, create weighted 
     averages of the members of selected clusters ("cluster representatives"),

--- a/man/css.Rd
+++ b/man/css.Rd
@@ -93,10 +93,10 @@ selection.}
 \value{
 A list containing the following items: \item{feat_sel_mat}{A B (or
 2B for sampling.method "SS") x p numeric (binary) matrix.
-feat_sel_mat\link{i, j} = 1 if feature j was selected by the base feature
+\code{feat_sel_mat[i, j] = 1} if feature j was selected by the base feature
 selection method on subsample i, and 0 otherwise.} \item{clus_sel_mat}{A B
 (or 2*B for SS sampling) x length(selected) numeric (binary) matrix.
-clus_sel_mat\link{i, j} = 1 if at least one feature from cluster j was selected by
+\code{clus_sel_mat[i, j] = 1} if at least one feature from cluster j was selected by
 the base feature selection method on subsample i, and 0 otherwise.}
 \item{X}{The X matrix provided to css.} \item{y}{The y vector provided to
 css.} \item{clusters}{A named list of integer vectors containing all of the

--- a/man/cssPredict.Rd
+++ b/man/cssPredict.Rd
@@ -24,8 +24,8 @@ split into two parts; half of the data will be used for feature selection by
 cluster stability selection, and half will be used for estimating a linear
 model on the selected cluster representatives.}
 
-\item{y_train}{A length-n numeric vector containing the responses; y\link{i} is the
-response corresponding to observation X\link{i, }.}
+\item{y_train}{A length-n numeric vector containing the responses; \code{y[i]} is the
+response corresponding to observation \code{X[i, ]}.}
 
 \item{X_predict}{A numeric matrix (preferably) or a data.frame (which will
 be coerced internally to a matrix by the function model.matrix) containing

--- a/man/cssSelect.Rd
+++ b/man/cssSelect.Rd
@@ -19,8 +19,8 @@ cssSelect(
 be coerced internally to a matrix by the function model.matrix) containing
 the p >= 2 features/predictors.}
 
-\item{y}{A length-n numeric vector containing the responses; y\link{i} is the
-response corresponding to observation X\link{i, }.}
+\item{y}{A length-n numeric vector containing the responses; \code{y[i]} is the
+response corresponding to observation \code{X[i, ]}.}
 
 \item{clusters}{Optional; either an integer vector of a list of integer
 vectors; each

--- a/man/print.cssr.Rd
+++ b/man/print.cssr.Rd
@@ -4,10 +4,10 @@
 \alias{print.cssr}
 \title{Print cluster stabilty selection output}
 \usage{
-\method{print}{cssr}(css_results, cutoff = 0, min_num_clusts = 0, max_num_clusts = NA)
+\method{print}{cssr}(x, cutoff = 0, min_num_clusts = 0, max_num_clusts = NA, ...)
 }
 \arguments{
-\item{css_results}{An object of class "cssr" (the output of the function
+\item{x}{An object of class "cssr" (the output of the function
 css).}
 
 \item{cutoff}{Numeric; print.cssr will display only those
@@ -25,6 +25,8 @@ use regardless of cutoff. (That is, if the chosen cutoff returns more than
 max_num_clusts clusters, the cutoff will be decreased until at most
 max_num_clusts clusters are selected.) Default is NA (in which case
 max_num_clusts is ignored).}
+
+\item{...}{Additional arguments (not used)}
 }
 \value{
 A data.frame; each row contains a cluster, arranged in decreasing


### PR DESCRIPTION
These changes were made to address the warnings/notes that arise when you run `devtools::check()`.  Mostly this has to do with namespace stuff, such as referring to `detectCores()` as `parallel::detectCores()`.

Some further notes:

- `glmnet` does not export `predict`, but rather `glmnet::predict.glmnet`, so I had to change the function name (same with `coef.glmnet`).
- It wants `print.cssr` to have the same arguments (`x` and `...`) as the generic.  I'm not sure if we're allowed to have those additional arguments, but it seemed to silence the note.
- In the documentation, when you use, e.g., `[i]`, it was being changed to `\link{i}`, which means that it was looking for a documented function named `i`.